### PR TITLE
Rename 'platform' flags to 'emulator'. Fixes #24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ retros cp /home/gamer/roms
 ```
 
 All ROM files in the provided directory will be copied to their respective
-platforms in RetroPie based on the file extensions.
+emulators in RetroPie based on the file extensions.
 
-#### Specifying the platform
+#### Specifying the emulator
 
 If a ROM file has a different extension, you can copy it by
-specifying the platform it should go into:
+specifying the emulator it should go into:
 
 ```bash
-retros cp --platform=atari2600 Game.bin
+retros cp --emulator=atari2600 Game.bin
 ```
 
 ### List
@@ -104,10 +104,10 @@ Lists the ROM files in RetroPie:
 retros ls
 ```
 
-To list ROM files for specific platforms:
+To list ROM files for specific emulators:
 
 ```bash
-retros ls -p=mastersystem
+retros ls -e=mastersystem
 ```
 
 ## Roadmap

--- a/src/cmd/cf.go
+++ b/src/cmd/cf.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 

--- a/src/cmd/check.go
+++ b/src/cmd/check.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 

--- a/src/cmd/cp.go
+++ b/src/cmd/cp.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 
@@ -53,13 +48,13 @@ copies Game.md to $HOME/RetroPie/roms/genesis.`,
 		fmt.Println("Copying ROM files")
 		fmt.Println()
 
-		platform, err := cmd.Flags().GetString("platform")
+		emulator, err := cmd.Flags().GetString("emulator")
 
 		if err != nil {
 			log.Fatalln(err)
 		}
 
-		err = copy(args[0], platform)
+		err = copy(args[0], emulator)
 
 		if err != nil {
 			log.Fatalf("Failed to copy ROM file. Error: %v", err)
@@ -69,11 +64,11 @@ copies Game.md to $HOME/RetroPie/roms/genesis.`,
 
 func init() {
 	rootCmd.AddCommand(cpCmd)
-	var platform string
-	cpCmd.PersistentFlags().StringVarP(&platform, "platform", "p", "", "The platform where the ROM file(s) will be copied to")
+	var emulator string
+	cpCmd.PersistentFlags().StringVarP(&emulator, "emulator", "e", "", "The emulator where the ROM file(s) will be copied to")
 }
 
-func copy(fsPath, platform string) error {
+func copy(fsPath, emulator string) error {
 	isDir, err := filesystem.CheckDir(fsPath)
 
 	if err != nil {
@@ -89,7 +84,7 @@ func copy(fsPath, platform string) error {
 
 		if len(files) > 0 {
 			for _, file := range files {
-				err := copyROMFile(path.Join(fsPath, file), platform)
+				err := copyROMFile(path.Join(fsPath, file), emulator)
 
 				if err != nil {
 					return err
@@ -100,7 +95,7 @@ func copy(fsPath, platform string) error {
 		return nil
 	}
 
-	err = copyROMFile(fsPath, platform)
+	err = copyROMFile(fsPath, emulator)
 
 	if err != nil {
 		return err
@@ -109,14 +104,14 @@ func copy(fsPath, platform string) error {
 	return nil
 }
 
-func copyROMFile(romFile, plat string) error {
+func copyROMFile(romFile, emulator string) error {
 	romsPath := "/home/pi/RetroPie/roms/"
 
-	if plat == "" {
-		plat = emulators.FindEmulatorFromExtension(romFile)
+	if emulator == "" {
+		emulator = emulators.FindEmulatorFromExtension(romFile)
 	}
 
-	romsPath = path.Join(romsPath, plat, filepath.Base(romFile))
+	romsPath = path.Join(romsPath, emulator, filepath.Base(romFile))
 
 	config, err := config.Read()
 

--- a/src/cmd/ls.go
+++ b/src/cmd/ls.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 
@@ -47,13 +42,13 @@ retros ls -p=snes     Lists all ROM files under snes/
 		fmt.Println("ROM files found: ")
 		fmt.Println()
 
-		platform, err := cmd.Flags().GetString("platform")
+		emulator, err := cmd.Flags().GetString("emulator")
 
 		if err != nil {
 			log.Fatalf("Failed to get cp flags: Error %t\n", err)
 		}
 
-		output, err := listROMFiles(platform)
+		output, err := listROMFiles(emulator)
 
 		if err != nil {
 			log.Fatalf("Failed to list ROM files. Error: %t\n", err)
@@ -66,11 +61,11 @@ retros ls -p=snes     Lists all ROM files under snes/
 
 func init() {
 	rootCmd.AddCommand(lsCmd)
-	var platform string
-	lsCmd.PersistentFlags().StringVarP(&platform, "platform", "p", "", "The platform for which to list ROM files.")
+	var emulator string
+	lsCmd.PersistentFlags().StringVarP(&emulator, "emulator", "e", "", "The emulator for which to list ROM files.")
 }
 
-func listROMFiles(platform string) (string, error) {
+func listROMFiles(emulator string) (string, error) {
 	romsPath := "/home/pi/RetroPie/roms/"
 
 	config, err := config.Read()
@@ -84,8 +79,8 @@ func listROMFiles(platform string) (string, error) {
 		return "", err
 	}
 
-	if platform != "" {
-		output, err := runLs(path.Join(romsPath, platform), client)
+	if emulator != "" {
+		output, err := runLs(path.Join(romsPath, emulator), client)
 
 		if err != nil {
 			return "", err
@@ -100,21 +95,21 @@ func listROMFiles(platform string) (string, error) {
 		return "", err
 	}
 
-	platforms := strings.Split(output, "\n")
+	emulators := strings.Split(output, "\n")
 	output = ""
 
 	var sb strings.Builder
 
-	for _, plat := range platforms {
-		if plat != "" {
-			output, err = runLs(path.Join(romsPath, plat), client)
+	for _, emu := range emulators {
+		if emu != "" {
+			output, err = runLs(path.Join(romsPath, emu), client)
 
 			if err != nil {
 				return "", err
 			}
 
 			if output != "" {
-				sb.WriteString(fmt.Sprintf("%s\n\n", strings.ToUpper(plat)))
+				sb.WriteString(fmt.Sprintf("%s\n\n", strings.ToUpper(emu)))
 				sb.WriteString(fmt.Sprintf("%s\n", output))
 				sb.WriteString("====================================================\n")
 			}

--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 
@@ -30,11 +25,13 @@ import (
 // rmCmd represents the rm command
 var rmCmd = &cobra.Command{
 	Use:   "rm",
-	Short: "Removes a ROM file",
-	Long: `Removes a ROM file or files from the machine where RetroPie is installed.
-For example:
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
 
-retros rm Game.ms				Removes "Game.ms" from $HOME/RetroPie/roms/mastersystem`,
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("rm called")
 	},

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,23 +1,18 @@
 /*
 Copyright © 2023 Robson William
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package cmd
 

--- a/src/emulators/emulators_test.go
+++ b/src/emulators/emulators_test.go
@@ -2,12 +2,12 @@ package emulators
 
 import "testing"
 
-func TestFindPlatformFromExtension(t *testing.T) {
+func TestFindEmulatorFromExtension(t *testing.T) {
 	expected := "snes"
 	actual := FindEmulatorFromExtension("C:\\Users\\Gamer\\ReallyCoolGame.sfc")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
@@ -15,7 +15,7 @@ func TestFindPlatformFromExtension(t *testing.T) {
 	actual = FindEmulatorFromExtension("gamer/games/ReallyHardGame.md")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
@@ -23,7 +23,7 @@ func TestFindPlatformFromExtension(t *testing.T) {
 	actual = FindEmulatorFromExtension("/home/gamer/ReallyNostalgicGame.sms")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
@@ -31,7 +31,7 @@ func TestFindPlatformFromExtension(t *testing.T) {
 	actual = FindEmulatorFromExtension("C:\\Users\\Gamer\\ReallyShortGame.gba")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
@@ -39,7 +39,7 @@ func TestFindPlatformFromExtension(t *testing.T) {
 	actual = FindEmulatorFromExtension("C:\\Users\\Gamer\\ReallyOld.a26")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
@@ -47,24 +47,24 @@ func TestFindPlatformFromExtension(t *testing.T) {
 	actual = FindEmulatorFromExtension("/home/gamer/ReallyRareGame.32x")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 }
 
-func TestFindPlatformFromExtension_GameCube(t *testing.T) {
+func TestFindEmulatorFromExtension_GameCube(t *testing.T) {
 	expected := "gc"
 	actual := FindEmulatorFromExtension("C:\\Users\\Gamer\\AGameCubeGame.gcm")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension_GameCube().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension_GameCube().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 
 	actual = FindEmulatorFromExtension("/home/pi/AnotherGameCubeGame.gcz")
 
 	if expected != actual {
-		t.Fatalf("Failed to FindPlatformFromExtension_GameCube().\nexpected: %s\nactual: %s", expected, actual)
+		t.Fatalf("Failed to TestFindEmulatorFromExtension_GameCube().\nexpected: %s\nactual: %s", expected, actual)
 		return
 	}
 


### PR DESCRIPTION
# Pull Request

## Description

Some commands have a flag called --platform or -p. The name "platform" is not used by RetroPie for the game consoles, instead they use the term "emulator" which is probably more appropriate in this context and should be used by RetroS too.

## Changes Made

- Replaced all "--platform" and "-p" flags with "--emulator" and "-e" respectively.
- Updated documentation

## Related Issues

Fixes #24

## Checklist

- [x] I have tested these changes locally.
- [x] My code follows the project's coding standards.
- [x] I have updated the documentation accordingly.
- [x] All tests pass.
- [x] I have added relevant comments to my code.

## Additional Comments

Licenses in the command files have been updated too.