### PR TITLE
Ignoring directories from 'ls' command

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -42,9 +42,6 @@ retros ls             Lists all ROM files
 retros ls -p=snes     Lists all ROM files under snes/
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("ROM files found: ")
-		fmt.Println()
-
 		emulator, err := cmd.Flags().GetString("emulator")
 
 		if err != nil {
@@ -56,6 +53,9 @@ retros ls -p=snes     Lists all ROM files under snes/
 		if err != nil {
 			log.Fatalf("Failed to list ROM files. Error: %v\n", err)
 		}
+
+		fmt.Printf("%s games found: \n", strings.ToUpper(emulator))
+		fmt.Println()
 
 		fmt.Println(output)
 	},
@@ -130,7 +130,7 @@ func listROMFiles(emulator string) (string, error) {
 }
 
 func runLs(dirPath string, client *ssh.Client) (string, error) {
-	lsCmd := "ls " + dirPath + " --ignore=*.state*" + " --ignore=*.srm"
+	lsCmd := "find " + dirPath + " -type f ! -name '*.state*' ! -name '*.srm' -exec basename {} \\;"
 
 	if client != nil {
 		output, err := sshutils.ExecuteRemoteCommand(client, lsCmd)


### PR DESCRIPTION
# Pull Request

## Description

Replaced the 'ls' command in the target machine for 'find' so that directories can be excluded.

## Changes Made

<!-- List the changes made in bullet points or provide a summary -->

- Using 'find' instead of 'ls'

## Related Issues

## Checklist

- [x] I have tested these changes locally.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass.
- [ ] I have added relevant comments to my code.

## Additional Comments

N/A
